### PR TITLE
Rename package to avoid conflict and add call to main

### DIFF
--- a/bag_merge/CMakeLists.txt
+++ b/bag_merge/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 2.8.3)
-project(bag_manager)
+project(bag_merge)
 
 ## Compile as C++11, supported in ROS Kinetic and newer
 add_compile_options(-std=c++11)
@@ -21,15 +21,15 @@ include_directories(
   ${catkin_INCLUDE_DIRS}
 )
 
-add_executable(merge_bags src/merge_bags.cpp)
+add_executable(${PROJECT_NAME}_merge_bags src/merge_bags.cpp)
 
-add_dependencies(merge_bags ${${PROJECT_NAME}_EXPORTED_TARGETS} ${catkin_EXPORTED_TARGETS})
+add_dependencies(${PROJECT_NAME}_merge_bags ${${PROJECT_NAME}_EXPORTED_TARGETS} ${catkin_EXPORTED_TARGETS})
 
-target_link_libraries(merge_bags
+target_link_libraries(${PROJECT_NAME}_merge_bags
     ${catkin_LIBRARIES}
 )
 
- install(TARGETS merge_bags
+ install(TARGETS ${PROJECT_NAME}_merge_bags
    ARCHIVE DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
    LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
    RUNTIME DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}

--- a/bag_merge/package.xml
+++ b/bag_merge/package.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0"?>
 <package format="2">
-  <name>bag_manager</name>
+  <name>bag_merge</name>
   <version>0.0.0</version>
   <description>Tools for working with ROS bag files</description>
 
-  <maintainer email="roland@ccom.unh.edu">Roland Arsenault</maintainer>
+  <maintainer email="Avery.Munoz@unh.edu">Avery Munoz</maintainer>
 
 
   <license>BSD</license>

--- a/msgext/msgext.py
+++ b/msgext/msgext.py
@@ -96,7 +96,8 @@ def main():
                             f.write(i + '\n')
                     f.close()
       
-      
+if __name__ == '__main__':
+    main()      
 
 
     


### PR DESCRIPTION
This is to allow building in a workspace with the bag_manager package. It also allows the msgext script to be run directly without needing to setup.